### PR TITLE
docs: add CLAUDE.md, fix README inaccuracies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ nb-configuration.xml
 
 # Plugin directory
 /.quarkus/cli/plugins/
+
+### Claude Code (local only) ###
+.claude/settings.local.json
+.claude/worktrees
+.superpowers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+CBOMkit generates, stores, views and compliance-checks **CBOMs** (Cryptography Bills of Materials, CycloneDX). Two deployables live in one repo:
+
+- **Backend** (`src/`) — Quarkus 3 / Java 21 REST + WebSocket API, Postgres via Hibernate Panache.
+- **Frontend** (`frontend/`) — Vue 2 + Carbon Design SPA. Also ships standalone as *CBOMkit-coeus* (viewer-only mode, `VUE_APP_VIEWER_ONLY=true`).
+
+The actual source-code scanning is **not** in this repo: it comes from the `org.pqca:cbomkit-lib` dependency (indexing + scanner services for Java/Python/Go, aka CBOMkit-hyperion / sonar-cryptography). This repo orchestrates clone → index → scan → persist → serve.
+
+## Build prerequisite
+
+`org.pqca:cbomkit-lib` is hosted on **GitHub Packages**, so Maven needs a `~/.m2/settings.xml` with a `github` server entry (username + PAT with `read:packages`). Without it every build fails at dependency resolution — that is the first thing to check on a resolution error, not the pom.
+
+## Commands
+
+```shell
+# backend
+./mvnw quarkus:dev                       # dev mode, port 8081 (needs Postgres, see below)
+./mvnw clean package                     # build (runs spotless+checkstyle+tests)
+./mvnw test                              # tests only
+./mvnw test -Dtest=GitServiceTest        # single test class
+./mvnw test -Dtest=GitServiceTest#method # single test method
+./mvnw spotless:apply                    # format + insert license headers
+./mvnw spotless:check
+./mvnw checkstyle:check
+
+# frontend (cd frontend/)
+npm ci
+npm run serve      # dev server on :8001
+npm run build
+npm run lint
+
+# environments (docker-compose profiles; ENGINE=podman also works)
+make dev           # postgres only          -> run backend + frontend locally
+make dev-backend   # postgres + frontend    -> run backend locally
+make dev-frontend  # postgres + backend     -> run frontend locally
+make production    # full stack
+make ext-compliance# full stack + OPA container serving opa/*.rego
+make coeus         # frontend only (viewer)
+```
+
+**Tests need a running Postgres.** All meaningful tests are `@QuarkusTest` and boot the app against `jdbc:postgresql://localhost:5432/postgres` (user/pass `cbomkit`). Start `make dev` first, or `mvn package` will fail on DB connect. Some tests (`GitServiceTest`, `PurlResolverTest`, `MavenPackageFinderService`) also hit the network.
+
+`make` targets resolve `VERSION` by curling the **latest GitHub release tag**, not the pom version — so `make production` runs released images, and `make build-backend-image` tags the locally built jar with the latest release tag.
+
+## Formatting is enforced at build time
+
+The spotless plugin binds `apply` (not `check`) to the `validate` phase, and checkstyle binds `check` there too. Any `./mvnw` invocation will silently reformat your Java sources (google-java-format, **AOSP style**, 4-space indent) and inject the Apache/PQCA license header. New `.java` files without the header are fixed automatically; don't hand-write it.
+
+## Architecture
+
+Layered DDD + CQRS, built on the `app.bootstrap.core` library (`AggregateRoot`, `Repository`, `ICommandBus`, `ProcessManager`, `Projector`, `DomainEventHandler`).
+
+```
+presentation/  JAX-RS resources + WebSocket endpoint  (com.ibm.presentation.api.v1)
+usecases/      commands, queries, handlers, process managers, projectors, services
+domain/        aggregates, value objects, domain events — no framework deps
+infrastructure/ buses, Panache entities, read models, compliance services, config
+```
+
+**ArchUnit enforces domain isolation** (`src/test/java/com/ibm/architecture/DomainTest.java`). `com.ibm.domain` may only depend on an explicit allowlist (`java..`, `app.bootstrap.core.ddd..`, `jakarta.annotation/inject`, `org.cyclonedx.model..`, `com.github.packageurl..`, `org.pqca.scanning..`). Adding any other import to a domain class breaks the build — either move the code to `usecases`/`infrastructure` or deliberately extend the allowlist.
+
+### Scan flow (the core of the system)
+
+1. `ScanningResource` (POST `/api/v1/scan`) or `WebsocketScanningResource` (`/v1/scan/{clientId}`) creates a `ScanId`, instantiates a **per-scan** `ScanProcessManager`, and registers it on the `CommandBus` for the scan's command types. The WebSocket path passes a `WebSocketProgressDispatcher` so the UI gets live progress; the REST path uses `EmptyProgressDispatcher`.
+2. `RequestScanCommandHandler` builds the `ScanAggregate`, which emits `ScanRequestedEvent` (git URL) or `PurlScanRequestedEvent` (PURL).
+3. `ScanEventHandler` turns those domain events into the first command (`CloneGitRepositoryCommand` / `ResolvePurlCommand`).
+4. `ScanProcessManager` is the saga: resolve PURL → clone (JGit) → identify package folder → index modules → scan, sending the next command to itself via the bus after each step and persisting aggregate state in between. Every handler starts with `if (this.scanId != command.id()) return;` because *all* registered process managers see every command. On failure it dispatches an `ERROR` progress message and calls `compensate`.
+5. `ScanFinishedEvent` → `CBOMProjector` writes the read model.
+
+Because process managers are registered per scan on a shared singleton `CommandBus`, and both buses dispatch on cached thread pools, scans run concurrently and asynchronously — nothing here is request-scoped.
+
+### Persistence: write model vs. read model
+
+- Write side: `ScanAggregate` ⇄ `Scan` Panache entity (`infrastructure/scanning/repositories`). This is a **state snapshot**, not an event store — events are only in-memory signals published on the `DomainEventBus`.
+- Read side: `CBOMReadModel` (`infrastructure/database/readmodels`) stores the serialized CBOM as a Postgres JSON column, keyed by `projectIdentifier` (a PURL, e.g. `pkg:github/keycloak/keycloak@<commit>`). This is what `/api/v1/cbom/**` serves.
+- Schema is managed by `quarkus.hibernate-orm.schema-management.strategy=update` — no migration tool.
+
+### Compliance
+
+`Configuration.getComplianceService()` picks the implementation once and caches it statically: if `cbomkit.ext-policies.opa-api-base` (`CBOMKIT_OPA_API_BASE`) is set **and** reachable, it uses `OPAComplianceService`, otherwise it falls back to the built-in `BasicQuantumSafeComplianceService` (OID/name whitelists). Because the choice is cached in a static field, changing the env var requires a restart.
+
+OPA policies live in `opa/*.rego`, package `policies`, rules named `<policy_name>.findings contains finding if ...`, where `<policy_name>` must equal the frontend's `VUE_APP_POLICY_NAME` (default `quantum_safe`). Each finding needs `bom-ref`, `result` (`quantum-safe|quantum-vulnerable|na|unknown`) and `rule`; a malformed finding makes CBOMkit fall back to the internal service. See README for the full contract.
+
+Note the frontend *also* has its own client-side quantum-safe check, used in coeus/viewer mode.
+
+### API surface
+
+`/api` (status), `/api/v1/scan` (POST), `/api/v1/cbom/last/{limit}`, `/api/v1/cbom/{projectIdentifier}` (GET/POST/DELETE), `/api/v1/compliance/check` (GET by project identifier, POST with a CBOM body), WebSocket `/v1/scan/{clientId}`. `openapi.yaml`/`openapi.json` at the repo root are generated by SmallRye (`quarkus.smallrye-openapi.store-schema-directory=./`) — regenerate rather than hand-edit.
+
+## Configuration
+
+Everything is env-driven through `src/main/resources/application.properties`: `CBOMKIT_PORT`, `CBOMKIT_DB_*`, `CBOMKIT_FRONTEND_URL_CORS`, `CBOMKIT_CLONEDIR` (temp clone dir, defaults to `~/.cbomkit`), `CBOMKIT_JAVA_JAR_DIR` (BouncyCastle jars in `src/main/resources/java/scan/`, used to resolve Java crypto symbols), `CBOMKIT_OPA_API_BASE`. Frontend uses `VUE_APP_*` (`frontend/.env.development`, `.env.production`).
+
+## Conventions worth matching
+
+- `jakarta.annotation.Nonnull` / `Nullable` on essentially every field, parameter and return — the codebase treats these as mandatory documentation.
+- Java 21 pattern-matching `switch` over sealed-ish command/event hierarchies in handlers; `default -> { // nothing }`.
+- Domain errors are dedicated exception classes under `domain/scanning/errors` and `usecases/*/errors`, not generic exceptions.
+- `final class` + constructor injection (no field `@Inject`).
+- Git credentials (PAT or user/password) are passed through commands to JGit and never logged or persisted; clones are deleted after the scan.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ make production ENGINE=podman
 
 (This requires podman-compose to have been installed via `pip3 install podman-compose`).
 
+To run the latest development build instead of the latest release, use the `edge` images:
+```shell
+make edge
+```
+
 Next steps:
 - Enter a git url like [https://github.com/keycloak/keycloak](https://github.com/keycloak/keycloak) or a package url (PURL) like `pkg:maven/io.quarkus/quarkus-core@3.18.1` to generate a CBOM
 - View your generated CBOM by selecting your previously scanned CBOM
@@ -59,6 +64,7 @@ helm install cbomkit \
 ## Architecture
 
 The CBOMkit consists of three integral components: a web frontend, an API server, and a database.
+In the `ext-compliance` deployment, an additional Open Policy Agent service is used for compliance evaluation (see [External Compliance Evaluation](#external-compliance-evaluation)).
 
 ### Frontend and CBOMkit-coeus
 
@@ -118,11 +124,14 @@ The compliance framework is designed with extensibility in mind, providing a sol
 
 CBOMkit supports the use of [Open Policy Agent (OPA)](https://www.openpolicyagent.org) as an external compliance evaluation service. OPA evaluates compliance based on user-defined policies written in its declarative policy language, [Rego](https://www.openpolicyagent.org/docs/policy-language).
 
-In CBOMkit, you can configure OPA as an external compliance compliance service using either:
+In CBOMkit, you can configure OPA as an external compliance service using either:
 - the environment variable `CBOMKIT_OPA_API_BASE`, or
 - the configuration key `cbomkit.ext-policies.opa-api-base` in [application.properties](src/main/resources/application.properties).
 
 If either option is specified, it must contain the base URL of a running OPA instance. If the variable or property is unset, or if CBOMkit cannot connect to OPA, the system automatically falls back to its built-in internal compliance service.
+
+> [!NOTE]
+> The compliance service is selected once, on first use, and then cached for the lifetime of the process. Changing `CBOMKIT_OPA_API_BASE` (or starting OPA after CBOMkit) therefore requires a restart of the API server to take effect.
 
 The internal compliance service implements a fixed “quantum-safe policy.” This built-in policy checks the quantum safety of asymmetric algorithms using whitelists of algorithm OIDs and names.
 
@@ -137,7 +146,7 @@ package policies
 
 Each rule includes:
 - A header,
-= A conditional expression (the logic), and
+- A conditional expression (the logic), and
 - A JSON object to be returned when the condition is satisfied.
 
 For compliance evaluation, OPA executes these rules on the set of CBOM components.
@@ -147,10 +156,17 @@ By convention, a rule header should follow this format:
 <policy_name>.findings contains finding if ...
 ```
 
-The <policy_name> identifies the policy being evaluated. It must match the policy name configured in the CBOMkit front end through the environment variable VUE_APP_POLICY_NAME.
-By default, this is "quantum_safe", the predefined policy included in quantum_safe.rego.
+The `<policy_name>` identifies the policy being evaluated. It must match the policy name configured in the CBOMkit front end through the environment variable `VUE_APP_POLICY_NAME`.
+By default, this is `quantum_safe`, the predefined policy included in [quantum_safe.rego](opa/quantum_safe.rego).
 
 When running CBOMkit as a Docker application via `make ext-compliance` (see below), the OPA container is automatically configured with this default policy file.
+If you run OPA yourself instead, you can push the sample policy to a running instance with [upload_quantum_safe.sh](opa/upload_quantum_safe.sh):
+
+```shell
+cd opa
+# defaults to http://localhost:8181, pass a different base URL as first argument
+./upload_quantum_safe.sh
+```
 
 ###### Findings Format
 Each policy must produce a JSON list named `findings`, which CBOMkit expects in OPA’s evaluation response.


### PR DESCRIPTION
## What

- **CLAUDE.md** (new) — guidance file for Claude Code: repo layout, build prerequisites (GitHub Packages auth for `org.pqca:cbomkit-lib`), commands, scan flow, write/read model split, compliance setup and code conventions.
- **README.md** — fixes found while checking it against the current code:
  - `<policy_name>` in the OPA section was written bare in prose, so GitHub's renderer swallowed it as an HTML tag ("The identifies the policy being evaluated."). Now backticked, along with `VUE_APP_POLICY_NAME` and `quantum_safe`.
  - Fixed a `=` that should have been `-` in the rule-structure list, and a duplicated word ("compliance compliance service").
  - Added a note that the compliance service is resolved once and cached in a static field (`infrastructure/Configuration.java`), so changing `CBOMKIT_OPA_API_BASE` requires a restart — the previous wording implied it was dynamic.
  - Documented `make edge` and `opa/upload_quantum_safe.sh`, both of which existed but were unmentioned.
  - Architecture overview now mentions the OPA service used in the `ext-compliance` deployment.
- **.gitignore** — ignore local-only Claude Code artifacts (`.claude/settings.local.json`, `.claude/worktrees`, `.superpowers`).

Docs only — no source changes.

## Out of scope

Two unrelated bugs surfaced during the README check, left for a separate PR:

- `VUE_APP_POLICY_NAME` is read in `frontend/src/app.config.js` but is not declared in `frontend/.env.development`, `.env.production`, or the compose `frontend` env, so it is only settable by rebuilding.
- The `Makefile` `deploy` target sets `--set cbomkit.tag`, but the chart's key is `backend.tag` (the README's helm snippet is correct).