### PR TITLE
ci: fix Docker build context broken by cbomkit-action leftovers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Dockerfile.jvm only needs the Quarkus build output and the BouncyCastle jars
+# used to resolve Java crypto symbols. Everything else is excluded so the build
+# context stays small and so unrelated files in the workspace (e.g. scratch
+# directories left behind by earlier workflow steps) can never break the build.
+**
+!target/quarkus-app/**
+!src/main/resources/java/scan/*.jar

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -74,17 +74,6 @@ jobs:
       - name: Update dependency graph
         uses: advanced-security/maven-dependency-submission-action@v5
         if: github.event_name != 'pull_request'
-      - name: Create CBOM
-        uses: cbomkit/cbomkit-action@v2.1.2
-        id: cbom
-          # Persist CBOM after a job has completed and share
-          # that CBOM with another job in the same workflow.
-      - name: Commit changes to new branch
-        uses: actions/upload-artifact@v4
-        with:
-          name: "CBOM"
-          path: ${{ steps.cbom.outputs.pattern }}
-          if-no-files-found: warn
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -117,3 +106,16 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+        # Runs last: the action is a root Docker action that leaves scratch
+        # directories in the workspace, which must not end up in a build context.
+      - name: Create CBOM
+        uses: cbomkit/cbomkit-action@v2.1.2
+        id: cbom
+          # Persist CBOM after a job has completed and share
+          # that CBOM with another job in the same workflow.
+      - name: Commit changes to new branch
+        uses: actions/upload-artifact@v4
+        with:
+          name: "CBOM"
+          path: ${{ steps.cbom.outputs.pattern }}
+          if-no-files-found: warn


### PR DESCRIPTION
## Problem

`main` has been red since c13e48a6 (#313, cbomkit-action 2.1.1 → 2.1.2). Every backend run now fails at **Build and push**:

```
ERROR: failed to solve: error from sender:
open 3d209dd94f134bfabcf39448cfbe63d5/11064971341617993163: permission denied
```

## Root cause

The action tag doesn't pin an image. Both tags' `Dockerfile` is `FROM …/cbomkit-action:edge` — a *mutable* tag — but v2.1.1 pointed at `ghcr.io/pqca/…` (old org, frozen since the org rename) while v2.1.2 points at `ghcr.io/cbomkit/…:edge` (live). The bump therefore swapped a stale 2025 image for today's `edge`, which includes the Go integration.

Running that image against a scratch workspace reproduces it — it leaves behind:

```
1fdfa6d97405491b8c15a7c58b22f0a8/
└── 13331845148632077365/          drwx------
    └── sonar-go-to-slang-linux-arm64
```

The Go scanner unpacks its helper binary via `createTempDirectory` rooted at the **CWD** (`/github/workspace`) rather than `java.io.tmpdir`. The action is a Docker action running `USER 0:0`, so on the runner that tree is root-owned and `0700`. `docker/build-push-action` sends `context: .` as the `runner` user, walks into it, and dies. The `Create CBOM` step itself still reports success — it just leaves droppings the next step trips over.

## Fix

There was no `.dockerignore`, so the entire tree (`.git`, `frontend/node_modules`, these leftovers) was shipped as build context — while `Dockerfile.jvm` only reads `target/quarkus-app/**` and `src/main/resources/java/scan/*.jar`. This PR whitelists exactly those, and moves the CBOM steps after the image build as defense in depth.

Verified locally against this repo with a simulated leftover directory: only the 2 whitelisted paths enter the context; the `0700` directory, `.git` and `frontend/` are never opened.

Sizeable build speedup as a side effect.

## Follow-ups for `cbomkit/cbomkit-action` (not fixed here)

- The Go helper should extract under `java.io.tmpdir`, not CWD.
- Release tags should pin a digest rather than `:edge` — right now `v2.1.2` means "whatever edge is today", so the action's behaviour changes under a fixed tag.