### PR TITLE
fix: store ScanResult.language as text instead of an enum ordinal

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,17 @@ Different deployment configurations utilize distinct sources for compliance veri
 | `production`     | In the standard deployment, a core compliance service is integrated into the backend service. This implementation enables the execution of compliance checks via the RESTful API, providing a scalable and centralized approach to cryptographic policy verification.                                                                                                                                                                |
 | `ext-compliance` | In advanced deployment scenarios, compliance evaluation is delegated to a dedicated external service. This service can invoked by the API server as needed. This configuration maintains the standard user experience for both the frontend and API of the CBOMkit, mirroring the functionality of the `production` configuration while allowing for more sophisticated or specialized compliance checks to be performed externally. |
 
+### Database Migrations
+
+The schema is managed by Hibernate (`quarkus.hibernate-orm.schema-management.strategy=update`), which
+only ever adds tables and columns. Changes it cannot apply — altering a column type or a constraint —
+are shipped as SQL scripts in [`migrations/`](migrations/) and have to be run once against existing
+databases, in file name order. A freshly created database never needs them.
+
+| Migration | Required for databases created before |
+|-----------|---------------------------------------|
+| [`2026-08-17-scanresult-language-as-text.sql`](migrations/2026-08-17-scanresult-language-as-text.sql) | Go support ([#345](https://github.com/cbomkit/cbomkit/issues/345)) |
+
 ### Handling of Credentials
 
 When a new scan of a GitHub repository is started, CBOMkit generates a temporary local clone

--- a/migrations/2026-08-17-scanresult-language-as-text.sql
+++ b/migrations/2026-08-17-scanresult-language-as-text.sql
@@ -1,0 +1,30 @@
+-- CBOMkit migration: store ScanResult.language as text instead of an enum ordinal
+--
+-- See https://github.com/cbomkit/cbomkit/issues/345
+--
+-- `language` used to be mapped as an unannotated Java enum, so Hibernate stored it as an ordinal
+-- and generated a check constraint listing the languages that existed when the table was created.
+-- `quarkus.hibernate-orm.schema-management.strategy=update` never rewrites a check constraint, so
+-- databases created while only JAVA and PYTHON existed reject every scan that reports a GO result.
+--
+-- Run this once against every database created before this change. Databases created afterwards
+-- already have a `varchar` column and no check constraint, and do not need it.
+--
+--   psql -U cbomkit -d postgres -f 2026-08-17-scanresult-language-as-text.sql
+--
+-- The CASE below maps the ordinals that were actually persisted. GO (2) is listed for completeness
+-- only: it never committed, since the constraint that this migration removes rejected it.
+
+BEGIN;
+
+ALTER TABLE scanresult DROP CONSTRAINT IF EXISTS scanresult_language_check;
+
+ALTER TABLE scanresult
+    ALTER COLUMN language TYPE varchar(255)
+        USING CASE language
+                  WHEN 0 THEN 'JAVA'
+                  WHEN 1 THEN 'PYTHON'
+                  WHEN 2 THEN 'GO'
+              END;
+
+COMMIT;

--- a/src/main/java/com/ibm/infrastructure/errors/AggregatePersistenceFailed.java
+++ b/src/main/java/com/ibm/infrastructure/errors/AggregatePersistenceFailed.java
@@ -1,0 +1,34 @@
+/*
+ * CBOMkit
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.infrastructure.errors;
+
+import app.bootstrap.core.ddd.Id;
+import jakarta.annotation.Nonnull;
+
+/**
+ * Thrown when an aggregate could not be written to the database. Unchecked because {@code
+ * IRepository#save} does not declare any checked exception.
+ */
+public class AggregatePersistenceFailed extends RuntimeException {
+
+    public AggregatePersistenceFailed(@Nonnull Id id, @Nonnull Exception cause) {
+        super("could not persist aggregate with id " + id, cause);
+    }
+}

--- a/src/main/java/com/ibm/infrastructure/scanning/repositories/Scan.java
+++ b/src/main/java/com/ibm/infrastructure/scanning/repositories/Scan.java
@@ -110,9 +110,18 @@ class Scan extends PanacheEntityBase {
         try {
             final Map<Language, LanguageScan> languageScans = new EnumMap<>(Language.class);
             for (ScanResult scanResult : scanResults) {
+                final Language language = scanResult.language();
+                if (language == null) {
+                    LOGGER.warn(
+                            "Skipping scan result of scan {}: '{}' is not a language supported by"
+                                    + " this version",
+                            this.id,
+                            scanResult.language);
+                    continue;
+                }
                 final LanguageScan languageScan =
                         new LanguageScan(
-                                scanResult.language,
+                                language,
                                 new ScanMetadata(
                                         scanResult.startTime.getTime(),
                                         scanResult.endTime.getTime(),

--- a/src/main/java/com/ibm/infrastructure/scanning/repositories/ScanRepository.java
+++ b/src/main/java/com/ibm/infrastructure/scanning/repositories/ScanRepository.java
@@ -23,6 +23,7 @@ import app.bootstrap.core.ddd.IDomainEventBus;
 import app.bootstrap.core.ddd.Repository;
 import com.ibm.domain.scanning.ScanAggregate;
 import com.ibm.domain.scanning.ScanId;
+import com.ibm.infrastructure.errors.AggregatePersistenceFailed;
 import com.ibm.infrastructure.errors.EntityNotFoundById;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
@@ -98,6 +99,9 @@ public final class ScanRepository extends Repository<ScanId, ScanAggregate>
             if (QuarkusTransaction.getStatus() != Status.STATUS_NO_TRANSACTION) {
                 QuarkusTransaction.rollback();
             }
+            // never swallow this: the caller would carry on and report a scan as finished while
+            // no state was written and no domain event was emitted
+            throw new AggregatePersistenceFailed(entity.getId(), e);
         } finally {
             container.requestContext().terminate();
         }

--- a/src/main/java/com/ibm/infrastructure/scanning/repositories/ScanResult.java
+++ b/src/main/java/com/ibm/infrastructure/scanning/repositories/ScanResult.java
@@ -22,6 +22,7 @@ package com.ibm.infrastructure.scanning.repositories;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
 import java.sql.Timestamp;
@@ -32,7 +33,18 @@ import org.pqca.scanning.Language;
 @Entity
 @Cacheable
 class ScanResult extends PanacheEntity {
-    @Nonnull public Language language;
+    /**
+     * Holds {@link Language#name()} and is deliberately <em>not</em> mapped as an enum: Hibernate
+     * emits a check constraint listing the known values for every enum typed attribute, whether it
+     * is stored as an ordinal, as {@code @Enumerated(STRING)} or through an {@code
+     * AttributeConverter} (see {@code EnumJavaType#getCheckCondition}). Since {@code
+     * quarkus.hibernate-orm.schema-management.strategy=update} never rewrites an existing check
+     * constraint, adding a language to cbomkit-lib would make every insert fail on databases that
+     * were created before that language existed. Storing plain text keeps the set of supported
+     * languages out of the schema.
+     */
+    @Nonnull public String language;
+
     @Nonnull public Timestamp startTime;
     @Nonnull public Timestamp endTime;
     public int numberOfScannedLines;
@@ -51,11 +63,23 @@ class ScanResult extends PanacheEntity {
             int numberOfScannedLines,
             int numberOfScannedFiles,
             @Nonnull JsonNode cbom) {
-        this.language = language;
+        this.language = language.name();
         this.startTime = new Timestamp(startTime);
         this.endTime = new Timestamp(endTime);
         this.numberOfScannedLines = numberOfScannedLines;
         this.numberOfScannedFiles = numberOfScannedFiles;
         this.cbom = cbom;
+    }
+
+    /**
+     * @return the stored language, or {@code null} if this row was written by a version of
+     *     cbomkit-lib that supported a language this version no longer knows.
+     */
+    @Nullable Language language() {
+        try {
+            return Language.valueOf(this.language);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/src/test/java/com/ibm/infrastructure/scanning/repositories/ScanResultLanguagePersistenceTest.java
+++ b/src/test/java/com/ibm/infrastructure/scanning/repositories/ScanResultLanguagePersistenceTest.java
@@ -1,0 +1,85 @@
+/*
+ * CBOMkit
+ * Copyright (C) 2024 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.infrastructure.scanning.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.domain.scanning.Commit;
+import com.ibm.domain.scanning.GitUrl;
+import com.ibm.domain.scanning.LanguageScan;
+import com.ibm.domain.scanning.ScanAggregate;
+import com.ibm.domain.scanning.ScanId;
+import com.ibm.domain.scanning.ScanMetadata;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import org.cyclonedx.model.Bom;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.pqca.scanning.CBOM;
+import org.pqca.scanning.Language;
+
+@QuarkusTest
+class ScanResultLanguagePersistenceTest {
+
+    @Inject ScanRepository repository;
+
+    /**
+     * Deliberately iterates {@link Language#values()} instead of listing languages, so that a
+     * language added to cbomkit-lib fails here rather than in production. See issue #345: an
+     * ordinal enum mapping left a stale {@code scanresult_language_check} constraint behind that
+     * rejected every scan once a third language existed.
+     */
+    @Test
+    @DisplayName("every language supported by cbomkit-lib can be persisted and read back")
+    void everyLanguageRoundTrips() throws Exception {
+        final ScanId scanId = new ScanId();
+        // reconstruct instead of requestScan: this test is about persistence and should not
+        // emit the domain events that kick off an actual scan
+        final ScanAggregate scanAggregate =
+                ScanAggregate.reconstruct(
+                        scanId,
+                        new GitUrl("https://github.com/pqca/cbomkit"),
+                        null,
+                        ScanAggregate.REVISION_MAIN,
+                        null,
+                        new Commit("0000000000000000000000000000000000000000"),
+                        null);
+
+        for (Language language : Language.values()) {
+            scanAggregate.reportScanResults(
+                    new LanguageScan(
+                            language, new ScanMetadata(0L, 1L, 2, 3), new CBOM(new Bom())));
+        }
+
+        try {
+            repository.save(scanAggregate);
+
+            final Optional<ScanAggregate> reloaded = repository.read(scanId);
+            assertThat(reloaded).isPresent();
+            assertThat(reloaded.get().getLanguageScans()).isPresent();
+            assertThat(reloaded.get().getLanguageScans().get())
+                    .extracting(LanguageScan::language)
+                    .containsExactlyInAnyOrder(Language.values());
+        } finally {
+            repository.delete(scanId);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #345.

## Problem

`ScanResult.language` was an unannotated enum, so Hibernate stored it as an ordinal and generated a check constraint listing the languages that existed when the table was created. Databases created while `Language` had only `JAVA(0)` / `PYTHON(1)` still carry `CHECK (language >= 0 AND language <= 1)`, and `schema-management.strategy=update` never rewrites a check constraint — so inserting `GO` (ordinal 2) fails.

This broke **every** scan, not just Go repositories: a `ScanResult` is written whenever the CBOM is non-null, and the Go scanner returns an empty CBOM even with zero Go projects, so the single transaction rolled back with the Java and Python results in it. `ScanRepository.save` swallowed the exception, so the scan still reported success over the WebSocket while `ScanFinishedEvent` was never emitted and nothing reached the read model.

## Why not `@Enumerated(EnumType.STRING)`

It does not help. The constraint is emitted by `EnumJavaType#getCheckCondition`, keyed on the attribute's domain type being an enum rather than on the storage strategy — it would simply become `check (language in ('JAVA','PYTHON','GO'))` and break again on the next language. Its `renderConvertedEnumCheckConstraint` method means an `AttributeConverter` does not escape it either, and `AvailableSettings` has no global off-switch. Only a non-enum Java type keeps the set of languages out of the schema.

## Changes

- Map the column as `String` holding `Language.name()`, with a comment recording why it must not be "cleaned up" back into an enum
- Skip unknown language names in `Scan#asAggregate` with a warning, so a language *removed* upstream cannot make stored scans unreadable
- Let `ScanRepository#save` throw `AggregatePersistenceFailed` instead of swallowing failures, so `ScanProcessManager` dispatches an `ERROR` rather than reporting success. Every call site is already inside a try that dispatches `ERROR`, compensates and rethrows, so no changes were needed there
- Add a round-trip test over `Language.values()`, so a language added to cbomkit-lib fails the build rather than production
- Ship the one-off migration in `migrations/`, referenced from the README

## Migration required

`update` cannot alter a column type or drop a constraint, so [`migrations/2026-08-17-scanresult-language-as-text.sql`](migrations/2026-08-17-scanresult-language-as-text.sql) must be run once against every database created before Go support. Databases created after this change need nothing.

```shell
psql -U cbomkit -d postgres -f migrations/2026-08-17-scanresult-language-as-text.sql
```

## Verification

- Full suite passes (22/22), including the ArchUnit `DomainTest`
- The new test is a genuine guard, not just a passing test: with a simulated stale constraint (`CHECK (language IN ('JAVA','PYTHON'))`) it errors. That run also confirmed the `save` change — it surfaced as an error propagating out of `save`, not a silent assertion failure
- The async scan in `ScanningResourceTest` persisted a `GO` row (JAVA 74→75, PYTHON 72→73) against a migrated database — the exact insert that was failing
- After Hibernate's schema update ran against the migrated database, no check constraint was recreated, which is the invariant this fix relies on

## Deliberately out of scope

- `read` and `delete` still swallow exceptions; `read`'s empty-`Optional` contract is load-bearing for callers
- `ScanProcessManager` still persists a `ScanResult` for an empty CBOM. Skipping empty results would have masked this bug rather than fixed it, so it is worth considering separately
- Flyway. `update` cannot deploy constraint or column-type changes at all, so every future schema change needs a script like this one and a release note. Left for a separate discussion (#345)
